### PR TITLE
WSS and EXPRESS can share HTTP Port

### DIFF
--- a/_ur_addons/midi/@midi-build.mts
+++ b/_ur_addons/midi/@midi-build.mts
@@ -12,6 +12,11 @@ import { PR, FILE } from '@ursys/core';
 import FSE from 'fs-extra';
 import { copy } from 'esbuild-plugin-copy';
 import esbuild from 'esbuild';
+// http server
+import http from 'node:http';
+import https from 'node:https';
+import express from 'express';
+import serveIndex from 'serve-index';
 
 /// CONSTANTS & DECLARATIONS //////////////////////////////////////////////////
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -47,14 +52,36 @@ async function ESBuildApp() {
       })
     ]
   });
+  // activate rebuild on change
   await context.watch();
-  // The return value tells us where esbuild's local server is
-  let { host, port } = await context.serve({
-    servedir: DST,
-    port: 8888
+
+  // add express
+  const APP = express();
+  APP.get('/', serveIndex(DST));
+  APP.use(express.static(DST));
+
+  // Listen both http & https ports
+  const httpServer = http.createServer(APP);
+  const httpsServer = https.createServer(
+    {
+      key: FSE.readFileSync('/etc/letsencrypt/live/ursys.dsri.xyz/privkey.pem'),
+      cert: FSE.readFileSync('/etc/letsencrypt/live/ursys.dsri.xyz/fullchain.pem')
+    },
+    APP
+  );
+
+  const http_port = 8080;
+  const https_port = 8443;
+  const http_host = '127.0.0.1';
+  const https_host = 'ursys.dsri.xyz';
+
+  httpServer.listen(http_port, () => {
+    console.log(`HTTP Server running on ${http_host}:${http_port}`);
   });
-  if (host === '0.0.0.0') host = 'localhost';
-  LOG('appserver is listening at', `http://${host}:${port}`);
+
+  httpsServer.listen(https_port, () => {
+    console.log(`HTTPS Server running on ${https_host}:${https_port}`);
+  });
 }
 
 /// EXPORTS ///////////////////////////////////////////////////////////////////

--- a/_ur_addons/net/class-urnet-endpoint.ts
+++ b/_ur_addons/net/class-urnet-endpoint.ts
@@ -39,6 +39,7 @@ import {
   IsLocalMessage,
   IsNetMessage,
   IsValidAddress,
+  SkipOriginType,
   AllocateAddress,
   NormalizeMessage,
   NormalizeData
@@ -112,7 +113,7 @@ class NetEndpoint {
   //
   cli_gateway: I_NetSocket; // gateway to server
   srv_socks: SocketMap; // uaddr->I_NetSocket
-  srv_msgs: ForwardMap; // msg->uaddr[]
+  remote_msgs: ForwardMap; // msg->uaddr[]
   msg_handlers: HandlerMap; // msg->handlers[]
   transactions: TransactionMap; // hash->resolver
   //
@@ -134,7 +135,7 @@ class NetEndpoint {
     this.cli_gateway = undefined; // client gateway
     // endpoint as server
     this.srv_socks = undefined;
-    this.srv_msgs = undefined;
+    this.remote_msgs = undefined;
     // endpoint message handling support
     this.msg_handlers = new Map<NP_Msg, HandlerSet>();
     this.transactions = new Map<NP_Hash, PktResolver>();
@@ -162,9 +163,9 @@ class NetEndpoint {
     if (this.srv_socks !== undefined)
       LOG(this.urnet_addr, `already configured`, [...this.srv_socks.keys()]);
     this.srv_socks = new Map<NP_Address, I_NetSocket>();
-    if (this.srv_msgs !== undefined)
-      LOG(this.urnet_addr, `already configured`, [...this.srv_msgs.keys()]);
-    this.srv_msgs = new Map<NP_Msg, AddressSet>();
+    if (this.remote_msgs !== undefined)
+      LOG(this.urnet_addr, `already configured`, [...this.remote_msgs.keys()]);
+    this.remote_msgs = new Map<NP_Msg, AddressSet>();
     // add default service message handlers here
     this.registerMessage('SRV:REFLECT', data => {
       data.info = `built-in service`;
@@ -174,7 +175,7 @@ class NetEndpoint {
 
   /** return true if this endpoint is managing connections */
   isServer() {
-    return this.srv_socks !== undefined && this.srv_msgs !== undefined;
+    return this.srv_socks !== undefined && this.remote_msgs !== undefined;
   }
 
   /** socket utilities  - - - - - - - - - - - - - - - - - - - - - - - - - - **/
@@ -330,7 +331,7 @@ class NetEndpoint {
     socket.auth = undefined; // filled-in by socket authorization
     socket.msglist = undefined; // filled-in by message registration
     this.srv_socks.set(new_uaddr, socket);
-    // if (DBG) LOG(this.urnet_addr, `socket ${new_uaddr} registered`);
+    // LOG(this.urnet_addr, `socket ${new_uaddr} registered`);
     return new_uaddr;
   }
 
@@ -351,11 +352,11 @@ class NetEndpoint {
       return undefined;
     }
     if (!this.srv_socks.has(uaddr)) throw Error(`${fn} unknown uaddr ${uaddr}`);
-    // srv_msgs is msg->set of uaddr, so iterate over all messages
+    // remote_msgs is msg->set of uaddr, so iterate over all messages
     this._delRemoteMessages(uaddr);
     // delete the socket
     this.srv_socks.delete(uaddr);
-    // if (DBG) LOG(this.urnet_addr, `socket ${uaddr} deleted`);
+    // LOG(this.urnet_addr, `socket ${uaddr} deleted`);
     return uaddr;
   }
 
@@ -368,7 +369,7 @@ class NetEndpoint {
         this.srv_socks.forEach((socket, uaddr) => {
           socket.age += AGE_INTERVAL;
           if (socket.age > AGE_MAX) {
-            if (DBG) LOG(this.urnet_addr, `socket ${uaddr} expired`);
+            LOG(this.urnet_addr, `socket ${uaddr} expired`);
             // put stuff here
           }
         });
@@ -377,7 +378,7 @@ class NetEndpoint {
     }
     if (this.cli_sck_timer) clearInterval(this.cli_sck_timer);
     this.cli_sck_timer = null;
-    if (DBG) LOG(this.urnet_addr, `timer stopped`);
+    LOG(this.urnet_addr, `timer stopped`);
   }
 
   /** client connection handshaking - - - - - - - - - - - - - - - - - - - - **/
@@ -395,7 +396,7 @@ class NetEndpoint {
       if (this.handleAuthResponse(pkt)) return;
       if (this.handleRegResponse(pkt)) return;
     }
-    // 2. otherwise handle the netcall interface normally
+    // 2. otherwise handle the message interface normally
     this.pktReceive(pkt);
   }
 
@@ -441,7 +442,7 @@ class NetEndpoint {
     throw Error(`${fn} arg must be identity`);
   }
 
-  /** create a authentication packet, which is the first packet that must be sent
+  /** create an authentication packet, which is the first packet that must be sent
    *  after connecting to the server */
   newAuthPacket(authObj: TClientAuth): NetPacket {
     const pkt = this.newPacket('SRV:AUTH', { ...authObj });
@@ -554,13 +555,14 @@ class NetEndpoint {
     throw Error(`${fn} unexpected response`, declared);
   }
 
-  /** create a definition packet */
+  /** create a declaration packet shell */
   newDeclPacket(): NetPacket {
     const pkt = this.newPacket('SRV:DEF');
     pkt.setMeta('_decl', { rsvp: true });
     return pkt;
   }
 
+  /** handle declaration packet */
   handleDeclResponse(pkt: NetPacket): boolean {
     const fn = 'handleDeclResponse:';
     if (pkt.msg_type !== '_decl') return false;
@@ -584,9 +586,9 @@ class NetEndpoint {
     if (!this.isServer()) return []; // invalid for client-only endpoints
     if (typeof uaddr !== 'string') throw Error(`${fn} invalid uaddr`);
     if (!this.srv_socks.has(uaddr)) throw Error(`${fn} unknown uaddr ${uaddr}`);
-    // srv_msgs is msg->set of uaddr, so iterate over all messages
+    // remote_msgs is msg->set of uaddr, so iterate over all messages
     const msg_list: NP_Msg[] = [];
-    this.srv_msgs.forEach((addr_set, msg) => {
+    this.remote_msgs.forEach((addr_set, msg) => {
       if (addr_set.has(uaddr)) msg_list.push(msg);
     });
     return msg_list;
@@ -598,8 +600,8 @@ class NetEndpoint {
     if (!this.isServer()) return []; // invalid for client-only endpoints
     if (typeof msg !== 'string') throw Error(`${fn} invalid msg`);
     const key = NormalizeMessage(msg);
-    if (!this.srv_msgs.has(key)) this.srv_msgs.set(key, new Set<NP_Address>());
-    const addr_set = this.srv_msgs.get(key);
+    if (!this.remote_msgs.has(key)) this.remote_msgs.set(key, new Set<NP_Address>());
+    const addr_set = this.remote_msgs.get(key);
     const addr_list = Array.from(addr_set);
     return addr_list;
   }
@@ -667,10 +669,11 @@ class NetEndpoint {
       if (typeof msg !== 'string') throw Error(`${fn} invalid msg`);
       if (msg !== msg.toUpperCase()) throw Error(`${fn} msg must be uppercase`);
       const key = NormalizeMessage(msg);
-      if (!this.srv_msgs.has(key)) this.srv_msgs.set(key, new Set<NP_Address>());
-      const msg_set = this.srv_msgs.get(key);
+      if (!this.remote_msgs.has(key))
+        this.remote_msgs.set(key, new Set<NP_Address>());
+      const msg_set = this.remote_msgs.get(key);
       msg_set.add(uaddr);
-      // if (DBG) LOG(this.urnet_addr, `reg remote ${key} for ${uaddr}`);
+      // LOG(this.urnet_addr, `reg remote ${key} for ${uaddr}`);
     });
   }
 
@@ -680,7 +683,7 @@ class NetEndpoint {
     if (typeof uaddr !== 'string') throw Error(`${fn} invalid uaddr`);
     if (!this.srv_socks.has(uaddr)) throw Error(`${fn} unknown uaddr ${uaddr}`);
     const removed = [];
-    this.srv_msgs.forEach((msg_set, key) => {
+    this.remote_msgs.forEach((msg_set, key) => {
       if (msg_set.has(uaddr)) removed.push(key);
       msg_set.delete(uaddr);
     });
@@ -727,7 +730,7 @@ class NetEndpoint {
   /** declare a message handler for a given message */
   registerMessage(msg: NP_Msg, handler: HandlerFunc) {
     const fn = 'registerMessage:';
-    // if (DBG) LOG(this.urnet_addr, `reg handler '${msg}'`);
+    // LOG(this.urnet_addr, `reg handler '${msg}'`);
     if (typeof msg !== 'string') throw Error(`${fn} invalid msg`);
     if (msg !== msg.toUpperCase()) throw Error(`${fn} msg must be uppercase`);
     if (typeof handler !== 'function') throw Error(`${fn} invalid handler`);
@@ -937,7 +940,7 @@ class NetEndpoint {
       // if it's a signal, this is not an rsvp, but log it for
       // internal debug purposes (doesn't affect function)
       if (pkt.msg_type === 'signal') {
-        if (DBG) LOG(_PKT(this, fn, '-recv-sig-', pkt), pkt.data);
+        // LOG(_PKT(this, fn, '-recv-sig-', pkt), pkt.data);
         LOG('would handle signal', pkt.msg);
       }
       // check to see if there are any handlers defined in this
@@ -950,7 +953,7 @@ class NetEndpoint {
       let retData;
       if (this.msg_handlers.has(msg)) {
         retData = await this.pktAwaitHandlers(pkt);
-      } else if (this.srv_msgs.has(msg)) {
+      } else if (this.remote_msgs.has(msg)) {
         retData = await this.pktAwaitRequest(pkt);
       } else {
         LOG(this.urnet_addr, fn, `unknown message '${msg}'`, pkt);
@@ -996,7 +999,7 @@ class NetEndpoint {
     if (pkt.msg_type !== 'ping' && pkt.data === undefined)
       throw Error(`${fn} data undefined`);
     // prep for sending
-    if (DBG) LOG(_PKT(this, fn, '-send-req-', pkt), pkt.data);
+    // LOG(_PKT(this, fn, '-send-req-', pkt), pkt.data);
     const { gateway, clients } = this.pktGetSocketRouting(pkt);
     // send on the wire
     pkt.addHop(this.urnet_addr);
@@ -1020,6 +1023,15 @@ class NetEndpoint {
     clone.id = this.assignPacketId(clone);
     const hash = GetPacketHashString(clone);
     if (this.transactions.has(hash)) throw Error(`${fn} duplicate hash ${hash}`);
+    const { src_addr } = pkt;
+    const { uaddr: dst_addr } = sock;
+    LOG(`${pkt.msg} dst:${dst_addr} src:${src_addr}`);
+    // for send and call packets, do not send to origin
+    if (src_addr === dst_addr && SkipOriginType(pkt.msg_type)) {
+      // LOG(`.. skipping reflect '${pkt.msg}' to ${dst_addr}==${src_addr}`);
+      return undefined;
+    }
+    // otherwise Promise
     const p = new Promise((resolve, reject) => {
       const meta = { msg: pkt.msg, uaddr: pkt.src_addr };
       this.transactions.set(hash, { resolve, reject, ...meta });
@@ -1033,7 +1045,7 @@ class NetEndpoint {
    */
   pktResolveRequest(pkt: NetPacket) {
     const fn = 'pktResolveRequest:';
-    // if (DBG) LOG(this.urnet_addr, 'resolving', pkt.msg);
+    // LOG(this.urnet_addr, 'resolving', pkt.msg);
     if (pkt.hop_rsvp !== true) throw Error(`${fn} packet is not RSVP`);
     if (pkt.hop_dir !== 'res') throw Error(`${fn} packet is not a response`);
     if (pkt.hop_seq.length < 2 && !pkt.isProtocol())
@@ -1043,7 +1055,7 @@ class NetEndpoint {
     if (!resolver) throw Error(`${fn} no resolver for hash ${hash}`);
     const { resolve, reject } = resolver;
     const { data } = pkt;
-    if (DBG) LOG(_PKT(this, fn, '-recv-res-', pkt), pkt.data);
+    // LOG(_PKT(this, fn, '-recv-res-', pkt), pkt.data);
     if (pkt.err) reject(pkt.err);
     else resolve(data);
     this.transactions.delete(hash);
@@ -1062,10 +1074,10 @@ class NetEndpoint {
     // prep for return
     pkt.setDir('res');
     pkt.addHop(this.urnet_addr);
-    if (DBG) LOG(_PKT(this, fn, '-send-res-', pkt), pkt.data);
+    // LOG(_PKT(this, fn, '-send-res-', pkt), pkt.data);
     const { gateway, src_addr } = this.pktGetSocketRouting(pkt);
     if (this.isServer()) {
-      // if (DBG) LOG(this.urnet_addr, 'returning to', src_addr);
+      // LOG(this.urnet_addr, 'returning to', src_addr);
       const socket = this.getClient(src_addr);
       if (socket) socket.send(pkt);
       // responses go to a single address; if we found it here,
@@ -1078,7 +1090,7 @@ class NetEndpoint {
       gateway.send(pkt);
       return;
     }
-    if (DBG) LOG(`${fn} unroutable packet`, pkt);
+    LOG(`${fn} unroutable packet`, pkt);
   }
 
   /** Start a transaction, which returns promises to await. This method
@@ -1092,19 +1104,21 @@ class NetEndpoint {
     const { gateway, clients } = this.pktGetSocketRouting(pkt);
     const promises = [];
     if (gateway) {
-      if (DBG) LOG(_PKT(this, fn, '-wait-req-', pkt), pkt.data);
-      promises.push(this.pktQueueRequest(pkt, gateway));
+      // LOG(_PKT(this, fn, '-wait-req-', pkt), pkt.data);
+      const p = this.pktQueueRequest(pkt, gateway);
+      if (p) promises.push(p);
     }
     if (Array.isArray(clients)) {
-      if (DBG) LOG(_PKT(this, fn, '-wait-req-', pkt), pkt.data);
+      // LOG(_PKT(this, fn, '-wait-req-', pkt), pkt.data);
       clients.forEach(sock => {
-        // if (DBG) LOG(this.urnet_addr, 'await remote', pkt.msg, sock.uaddr);
-        promises.push(this.pktQueueRequest(pkt, sock));
+        // LOG(this.urnet_addr, 'await remote', pkt.msg, sock.uaddr);
+        const p = this.pktQueueRequest(pkt, sock);
+        if (p) promises.push(p);
       });
     }
     let data = await Promise.all(promises);
     if (Array.isArray(data) && data.length === 1) data = data[0];
-    if (DBG) LOG(_PKT(this, fn, '-retn-req-', pkt), pkt.data);
+    // LOG(_PKT(this, fn, '-retn-req-', pkt), pkt.data);
     return data;
   }
 
@@ -1118,7 +1132,7 @@ class NetEndpoint {
     if (handlers.length === 0)
       return Promise.resolve({ error: `no handler for '${msg}'` });
     const promises = [];
-    if (DBG) LOG(_PKT(this, fn, '-wait-hnd-', pkt), pkt.data);
+    // LOG(_PKT(this, fn, '-wait-hnd-', pkt), pkt.data);
     handlers.forEach(handler => {
       promises.push(
         new Promise((resolve, reject) => {
@@ -1132,7 +1146,7 @@ class NetEndpoint {
     });
     let data = await Promise.all(promises);
     if (Array.isArray(data) && data.length === 1) data = data[0];
-    if (DBG) LOG(_PKT(this, fn, '-retn-hnd-', pkt), pkt.data);
+    // LOG(_PKT(this, fn, '-retn-hnd-', pkt), pkt.data);
     return data;
   }
 

--- a/_ur_addons/net/class-urnet-endpoint.ts
+++ b/_ur_addons/net/class-urnet-endpoint.ts
@@ -165,7 +165,8 @@ class NetEndpoint {
     this.srv_msgs = new Map<NP_Msg, AddressSet>();
     // add default service message handlers here
     this.registerMessage('SRV:REFLECT', data => {
-      return { memo: 'defaults defined in Endpoint.configAsServer' };
+      data.info = `built-in service`;
+      return data;
     });
   }
 

--- a/_ur_addons/net/class-urnet-endpoint.ts
+++ b/_ur_addons/net/class-urnet-endpoint.ts
@@ -23,7 +23,7 @@
 
 \*\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\ * /////////////////////////////////////*/
 
-import { PR, CLASS } from '@ursys/core';
+import { PR } from '@ursys/core';
 import { NetPacket } from './class-urnet-packet.ts';
 import {
   NP_ID,
@@ -47,7 +47,7 @@ import {
 
 /// CONSTANTS & DECLARATIONS //////////////////////////////////////////////////
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-const DBG = false;
+const DBG = true;
 const PR = typeof process !== 'undefined' ? 'EndPoint'.padEnd(13) : 'EndPoint:';
 const LOG = (...args) => DBG && console.log(PR, ...args);
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -573,8 +573,15 @@ class NetEndpoint {
     return true;
   }
 
-  /** disables down the gateway */
+  /** shuts down the gateway to server, forcing close
+   *  Chrome 125.0.6422.77 doesn't seem to send a close frame on reload
+   *  Firefox 126.0 doesn't fire beforeunload
+   */
   disconnectAsClient() {
+    if (this.cli_gateway === undefined) return;
+    if (typeof this.cli_gateway.close === 'function') {
+      this.cli_gateway.close();
+    }
     this.cli_gateway = undefined;
   }
 
@@ -1025,7 +1032,7 @@ class NetEndpoint {
     if (this.transactions.has(hash)) throw Error(`${fn} duplicate hash ${hash}`);
     const { src_addr } = pkt;
     const { uaddr: dst_addr } = sock;
-    LOG(`${pkt.msg} dst:${dst_addr} src:${src_addr}`);
+    // LOG(`${pkt.msg} dst:${dst_addr} src:${src_addr}`);
     // for send and call packets, do not send to origin
     if (src_addr === dst_addr && SkipOriginType(pkt.msg_type)) {
       // LOG(`.. skipping reflect '${pkt.msg}' to ${dst_addr}==${src_addr}`);

--- a/_ur_addons/net/cli-serve-control.mts
+++ b/_ur_addons/net/cli-serve-control.mts
@@ -116,7 +116,7 @@ async function TerminateServers() {
       if (DBG_PROC) LOG.info(`.. sending SIGTERM to pid:${pid} ${identifier}`);
     } catch (err) {
       if (err.code === 'ESRCH') {
-        LOG(`.. '${e.key}' (pid ${pid}) has already exited`);
+        LOG(`.. '${e.key}' (pid ${pid}) zombie key removed`);
         await KV.DeleteKey(e.key);
       } else LOG(`** Error sending SIGTERM to process ${pid}:`, err.code);
     }

--- a/_ur_addons/net/client-uds.mts
+++ b/_ur_addons/net/client-uds.mts
@@ -60,7 +60,7 @@ function Connect(): Promise<boolean> {
       // 1. wire-up SERVER_LINK to the endpoint via our netsocket wrapper
       LOG(`Connected to server '${sock_file}'`);
       const send = pkt => SERVER_LINK.write(pkt.serialize());
-      const onData = data => EP._serverDataIngest(data, client_sock);
+      const onData = data => EP._ingestServerMessage(data, client_sock);
       const client_sock = new NetSocket(SERVER_LINK, { send, onData });
       SERVER_LINK.on('data', onData);
       SERVER_LINK.on('end', () => {

--- a/_ur_addons/net/client-wss.mts
+++ b/_ur_addons/net/client-wss.mts
@@ -46,7 +46,7 @@ function Connect(): Promise<boolean> {
       // 1. wire-up SERVER_LINK to the endpoint via our netsocket wrapper
       LOG(`Connected to server '${wss_url}'`);
       const send = pkt => SERVER_LINK.send(pkt.serialize()); // client send
-      const onData = data => EP._serverDataIngest(data, client_sock); // client receive
+      const onData = data => EP._ingestServerMessage(data, client_sock); // client receive
       const client_sock = new NetSocket(SERVER_LINK, { send, onData });
       SERVER_LINK.on('message', onData);
       SERVER_LINK.on('close', (code, reason) => {

--- a/_ur_addons/net/serve-http-app/client-http.ts
+++ b/_ur_addons/net/serve-http-app/client-http.ts
@@ -41,10 +41,16 @@ function Connect(): Promise<boolean> {
       LOG(...PR('Connected to server'));
       const send = pkt => SERVER_LINK.send(pkt.serialize());
       const onData = event => EP._ingestServerMessage(event.data, client_sock);
-      const client_sock = new NetSocket(SERVER_LINK, { send, onData });
+      const close = () => SERVER_LINK.close();
+      const client_sock = new NetSocket(SERVER_LINK, { send, onData, close });
       SERVER_LINK.addEventListener('message', onData);
       SERVER_LINK.addEventListener('close', () => {
         LOG(...PR('server closed connection'));
+        EP.disconnectAsClient();
+      });
+      // disconnect client on browser reload or close
+      // needed on chrome, which doesn't appear to send a websocket closeframe
+      window.addEventListener('beforeunload', () => {
         EP.disconnectAsClient();
       });
       // 2. start client; EP handles the rest

--- a/_ur_addons/net/serve-http-app/client-http.ts
+++ b/_ur_addons/net/serve-http-app/client-http.ts
@@ -7,6 +7,7 @@
 import { ConsoleStyler } from '@ursys/core';
 import { NetEndpoint } from '../../net/class-urnet-endpoint.ts';
 import { NetSocket } from '../../net/class-urnet-socket.ts';
+import { HTTP_CLIENT_INFO } from '../../net/urnet-constants-webclient.ts';
 
 /// CONSTANTS & DECLARATIONS //////////////////////////////////////////////////
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -32,9 +33,10 @@ function m_Sleep(ms, resolve?): Promise<void> {
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 /** create a client connection to the HTTP/WS server */
 function Connect(): Promise<boolean> {
+  const { wss_url } = HTTP_CLIENT_INFO;
   const promiseConnect = new Promise<boolean>(resolve => {
-    let wsURI = 'ws://localhost:3029/urnet-http';
-    SERVER_LINK = new WebSocket(wsURI);
+    LOG(...PR(`websocket connect to ${wss_url}`));
+    SERVER_LINK = new WebSocket(wss_url);
     SERVER_LINK.addEventListener('open', async () => {
       LOG(...PR('Connected to server'));
       const send = pkt => SERVER_LINK.send(pkt.serialize());

--- a/_ur_addons/net/serve-http-app/client-http.ts
+++ b/_ur_addons/net/serve-http-app/client-http.ts
@@ -40,7 +40,7 @@ function Connect(): Promise<boolean> {
     SERVER_LINK.addEventListener('open', async () => {
       LOG(...PR('Connected to server'));
       const send = pkt => SERVER_LINK.send(pkt.serialize());
-      const onData = event => EP._serverDataIngest(event.data, client_sock);
+      const onData = event => EP._ingestServerMessage(event.data, client_sock);
       const client_sock = new NetSocket(SERVER_LINK, { send, onData });
       SERVER_LINK.addEventListener('message', onData);
       SERVER_LINK.addEventListener('close', () => {
@@ -113,13 +113,13 @@ async function RegisterMessages() {
   }, 1000);
 }
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-function Disconnect(seconds = 60) {
+function Disconnect(seconds = 360) {
   return new Promise((resolve, reject) => {
     LOG(...PR(`waiting for ${seconds} seconds...`));
     m_Sleep(seconds * 1000, () => {
       resolve(true);
       SERVER_LINK.close();
-      LOG(...PR(`closing client connection...`));
+      LOG(...PR(`closing client connection after ${seconds}s...`));
     });
   });
 }

--- a/_ur_addons/net/serve-http-app/client-http.ts
+++ b/_ur_addons/net/serve-http-app/client-http.ts
@@ -83,34 +83,48 @@ async function RegisterMessages() {
   });
   const resdata = await EP.clientDeclare();
   if (DBG) LOG(...PR('EP.clientDeclare returned', resdata));
-
+  TestClientMessage();
+  // TestServerReflect();
+  // TestServerService();
+}
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+function TestClientMessage() {
+  const EP_UADDR = EP.urnet_addr;
   // test client-to-client netcall CLIENT_TEST
   LOG(...PR(`CLIENT_TEST ${EP_UADDR} invocation`));
   EP.netCall('NET:CLIENT_TEST', { uaddr: EP_UADDR }).then(retdata => {
     LOG(...PR(`CLIENT TEST ${EP_UADDR} resolved with `, retdata));
   });
-
-  // test client-to-server netcalls REFLECT and FAKE_SERVICE
-  // calls each one twice over 4 seconds
+}
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+function TestServerReflect() {
   let count = 0;
   let foo = setInterval(() => {
     if (count > 3) {
       clearInterval(foo);
       return;
     }
-    if (count % 2) {
-      EP.netCall('SRV:REFLECT', { foo: 'bar' }).then(refdata => {
-        if (refdata.foo !== 'bar') LOG(...PR('REFLECT foo failed', refdata));
-        else LOG(...PR(`REFLECT return success`, refdata));
-      });
-    } else {
-      EP.netCall('SRV:FAKE_SERVICE', { hello: 'world' }).then(res => {
-        if (res.memo === undefined) LOG(...PR('FAKE_SERVICE memo failed', res));
-        else LOG(...PR(`FAKE_SERVICE return success`, res));
-      });
-    }
+    EP.netCall('SRV:REFLECT', { foo: 'bar' }).then(refdata => {
+      if (refdata.foo !== 'bar') LOG(...PR('REFLECT foo failed', refdata));
+      else LOG(...PR(`REFLECT return success`, refdata));
+    });
     count++;
-  }, 1000);
+  }, 1500);
+}
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+function TestServerService() {
+  let count = 0;
+  let foo = setInterval(() => {
+    if (count > 3) {
+      clearInterval(foo);
+      return;
+    }
+    EP.netCall('SRV:FAKE_SERVICE', { hello: 'world' }).then(res => {
+      if (res.memo === undefined) LOG(...PR('FAKE_SERVICE memo failed', res));
+      else LOG(...PR(`FAKE_SERVICE return success`, res));
+    });
+    count++;
+  }, 2000);
 }
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 function Disconnect(seconds = 360) {

--- a/_ur_addons/net/serve-http.mts
+++ b/_ur_addons/net/serve-http.mts
@@ -65,7 +65,6 @@ async function BuildApp() {
   const { es_target } = ESBUILD_INFO;
   FILE.EnsureDir(http_docs);
   const entryFile = `${app_src}/${app_entry}`;
-  console.log(`entryFile: ${entryFile}`);
   if (!FILE.FileExists(entryFile)) throw Error(`${fn} missing entry ${entryFile}`);
   const indexFile = `${app_src}/${app_index}`;
   if (!FILE.FileExists(indexFile)) throw Error(`${fn} missing index ${indexFile}`);

--- a/_ur_addons/net/serve-http.mts
+++ b/_ur_addons/net/serve-http.mts
@@ -233,7 +233,7 @@ async function Listen() {
   WSS.on('connection', (client_link, request) => {
     const send = pkt => client_link.send(pkt.serialize());
     const onData = data => {
-      const returnPkt = EP._clientDataIngest(data, client_sock);
+      const returnPkt = EP._ingestClientMessage(data, client_sock);
       if (returnPkt) client_link.send(returnPkt.serialize());
     };
     const client_sock = new NetSocket(client_link, { send, onData });

--- a/_ur_addons/net/serve-http.mts
+++ b/_ur_addons/net/serve-http.mts
@@ -235,7 +235,8 @@ async function Listen() {
       const returnPkt = EP._ingestClientMessage(data, client_sock);
       if (returnPkt) client_link.send(returnPkt.serialize());
     };
-    const client_sock = new NetSocket(client_link, { send, onData });
+    const close = () => client_link.close();
+    const client_sock = new NetSocket(client_link, { send, onData, close });
     if (EP.isNewSocket(client_sock)) {
       EP.addClient(client_sock);
       const uaddr = client_sock.uaddr;
@@ -245,11 +246,11 @@ async function Listen() {
     client_link.on('message', onData);
     client_link.on('end', () => {
       const uaddr = EP.removeClient(client_sock);
-      LOG(`${uaddr} client disconnected`);
+      LOG(`${uaddr} client 'end' disconnect`);
     });
     client_link.on('close', () => {
-      const { uaddr } = client_sock;
-      LOG(`${uaddr} client disconnected`);
+      const uaddr = EP.removeClient(client_sock);
+      LOG(`${uaddr} client 'close' disconnect`);
     });
     client_link.on('error', err => {
       LOG.error(`.. socket error: ${err}`);

--- a/_ur_addons/net/serve-http.mts
+++ b/_ur_addons/net/serve-http.mts
@@ -9,6 +9,7 @@
 
 import http from 'node:http';
 import fs from 'node:fs';
+import path from 'node:path';
 import express from 'express';
 import serveIndex from 'serve-index';
 import esbuild from 'esbuild';
@@ -125,6 +126,13 @@ function ServeAppIndex(req: express.Request, res: express.Response) {
 /** Parse ursys.dsri.xyz nginx config for locations */
 function m_PromiseProxyLocations(): Promise<Array<any>> {
   const nginxConf = '/etc/nginx/sites-enabled/ursys_dsri_xyz';
+  // local install? then just return root
+  if (!FILE.FileExists(nginxConf)) {
+    const base = path.basename(nginxConf);
+    LOG.info(`HTTP URNET Server nginx config '${base}' not present`);
+    return Promise.resolve(['/']);
+  }
+  // otherwise, parse nginx config
   return new Promise((resolve, reject) => {
     if (m_proxy_locations !== undefined) {
       resolve(m_proxy_locations);

--- a/_ur_addons/net/serve-http.mts
+++ b/_ur_addons/net/serve-http.mts
@@ -190,7 +190,7 @@ async function Start() {
 function Stop() {
   return new Promise<void>(resolve => {
     const { http_url, wss_path } = HTTP_INFO;
-    LOG.info(`.. stopping HTTP WebSocketServer on ${http_url}${wss_path}`);
+    LOG.info(`.. stopping HTTP WebSocketServer on ${http_url}/${wss_path}`);
     WSS.clients.forEach(client => client.close());
     WSS.close();
     LOG.info(`.. stopping HTTP AppServer on ${http_url}`);

--- a/_ur_addons/net/serve-http.mts
+++ b/_ur_addons/net/serve-http.mts
@@ -262,7 +262,9 @@ async function Listen() {
  *  by the demo client app
  */
 function X_RegisterServices() {
-  EP.registerMessage('SRV:MYSERVER', data => {
+  // SRV:REFLECT is built into URSYS, so don't define
+  EP.registerMessage('SRV:FAKE_SERVICE', data => {
+    LOG('FAKE_SERVICE received', data);
     return { memo: `defined in ${m_script}.X_RegisterServices` };
   });
   LOG.info(`HTTP URNET Server registered services`);

--- a/_ur_addons/net/serve-http.mts
+++ b/_ur_addons/net/serve-http.mts
@@ -8,7 +8,6 @@
 \*\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\ * /////////////////////////////////////*/
 
 import http from 'node:http';
-import https from 'node:https';
 import express from 'express';
 import serveIndex from 'serve-index';
 import esbuild from 'esbuild';
@@ -55,18 +54,19 @@ EP.configAsServer('SRV03'); // hardcode arbitrary server address
 
 /// HELPERS ///////////////////////////////////////////////////////////////////
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-async function HTTP_BuildApp() {
-  const fn = 'HTTP_BuildApp';
+async function BuildApp() {
+  const fn = 'BuildApp';
   const { http_docs, app_src, app_index } = HTTP_INFO;
   const { app_entry, app_bundle, app_bundle_map } = HTTP_INFO;
   const { es_target } = ESBUILD_INFO;
-  LOG.info(`HTTP Server building '${app_entry}' for '${app_index}'`);
   FILE.EnsureDir(http_docs);
   const entryFile = `${app_src}/${app_entry}`;
+  console.log(`entryFile: ${entryFile}`);
   if (!FILE.FileExists(entryFile)) throw Error(`${fn} missing entry ${entryFile}`);
   const indexFile = `${app_src}/${app_index}`;
   if (!FILE.FileExists(indexFile)) throw Error(`${fn} missing index ${indexFile}`);
   // esbuild build options
+  LOG.info(`HTTP Building Site'${app_entry}' from '${app_index}'`);
   const browserBuild: esbuild.BuildOptions = {
     entryPoints: [entryFile], // js file to start bundling
     target: [es_target], // js version to target
@@ -89,7 +89,6 @@ async function HTTP_BuildApp() {
             from: [`${app_src}/css/**/*`],
             to: [`${http_docs}/css`]
           },
-
           {
             from: [`${app_src}/${app_index}`],
             to: [`${http_docs}`]
@@ -109,9 +108,10 @@ async function HTTP_BuildApp() {
   // console.log(`${LOG.DIM}info: built ${app_entry} ${LOG.RST}`);
 }
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-function HTTP_Listen() {
-  const { http_port, http_host, http_docs, app_index } = HTTP_INFO;
+function Listen() {
+  const { http_port, http_host, http_docs, app_index, wss_path } = HTTP_INFO;
   FILE.EnsureDir(FILE.AbsLocalPath(http_docs));
+
   // configure HTTP server
   APP = express();
   if (SHOW_INDEX) {
@@ -128,70 +128,72 @@ function HTTP_Listen() {
   }
   // apply middleware
   APP.use(express.static(http_docs));
-  // start HTTP server
+
+  /** START HTTP SERVER **/
   SERVER = APP.listen(http_port, http_host, () => {
-    LOG.info(`HTTP Server listening at 'http://${http_host}:${http_port}'`);
+    LOG.info(`HTTP AppServer started on http://${http_host}:${http_port}`);
+  });
+  /** START WEBSOCKET SERVER with EXISTING HTTP SERVER **/
+  WSS = new WebSocketServer({
+    server: SERVER,
+    path: `/${wss_path}`, // requires leading slash
+    clientTracking: true
+  });
+  LOG.info(
+    `HTTP WebSocketServer started on ws://${http_host}:${http_port}/${wss_path}`
+  );
+  WSS.on('connection', (client_link, request) => {
+    const send = pkt => client_link.send(pkt.serialize());
+    const onData = data => {
+      const returnPkt = EP._clientDataIngest(data, client_sock);
+      if (returnPkt) client_link.send(returnPkt.serialize());
+    };
+    const client_sock = new NetSocket(client_link, { send, onData });
+    if (EP.isNewSocket(client_sock)) {
+      EP.addClient(client_sock);
+      const uaddr = client_sock.uaddr;
+      LOG(`${uaddr} client connected`);
+    }
+    // handle incoming data and return on wire
+    client_link.on('message', onData);
+    client_link.on('end', () => {
+      const uaddr = EP.removeClient(client_sock);
+      LOG(`${uaddr} client disconnected`);
+    });
+    client_link.on('close', () => {
+      const { uaddr } = client_sock;
+      LOG(`${uaddr} client disconnected`);
+    });
+    client_link.on('error', err => {
+      LOG.error(`.. socket error: ${err}`);
+    });
   });
 }
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-function WSS_RegisterServices() {
+function RegisterServices() {
   EP.registerMessage('SRV:MYSERVER', data => {
     return { memo: `defined in ${m_script}.RegisterServices` };
   });
+  LOG.info(`HTTP URNET Server registered services`);
   // note that default services are also registered in Endpoint
   // configAsServer() method
-}
-/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-function WSS_Listen() {
-  const { wss_port, wss_host, wss_url } = HTTP_INFO;
-  const options = { port: wss_port, host: wss_host, clientTracking: true };
-  WSS = new WebSocketServer(options, () => {
-    LOG.info(`HTTP/WSS Server listening on '${wss_url}'`);
-    WSS.on('connection', (client_link, request) => {
-      const send = pkt => client_link.send(pkt.serialize());
-      const onData = data => {
-        const returnPkt = EP._clientDataIngest(data, client_sock);
-        if (returnPkt) client_link.send(returnPkt.serialize());
-      };
-      const client_sock = new NetSocket(client_link, { send, onData });
-      if (EP.isNewSocket(client_sock)) {
-        EP.addClient(client_sock);
-        const uaddr = client_sock.uaddr;
-        LOG(`${uaddr} client connected`);
-      }
-      // handle incoming data and return on wire
-      client_link.on('message', onData);
-      client_link.on('end', () => {
-        const uaddr = EP.removeClient(client_sock);
-        LOG(`${uaddr} client disconnected`);
-      });
-      client_link.on('close', () => {
-        const { uaddr } = client_sock;
-        LOG(`${uaddr} client disconnected`);
-      });
-      client_link.on('error', err => {
-        LOG.error(`.. socket error: ${err}`);
-      });
-    });
-  });
 }
 
 /// API METHODS ///////////////////////////////////////////////////////////////
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 async function Start() {
-  await HTTP_BuildApp();
-  HTTP_Listen();
-  WSS_RegisterServices();
-  WSS_Listen();
+  await BuildApp();
+  RegisterServices();
+  Listen();
 }
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 function Stop() {
   return new Promise<void>(resolve => {
-    const { http_url, wss_url } = HTTP_INFO;
-    LOG.info(`.. stopping HTTP/WSS Server on ${wss_url}`);
+    const { http_url, wss_path } = HTTP_INFO;
+    LOG.info(`.. stopping HTTP WebSocketServer on ${http_url}${wss_path}`);
     WSS.clients.forEach(client => client.close());
     WSS.close();
-    LOG.info(`.. stopping HTTP Server on ${http_url}`);
+    LOG.info(`.. stopping HTTP AppServer on ${http_url}`);
     SERVER.close();
     const _checker = setInterval(() => {
       if (typeof WSS.clients.every !== 'function') {

--- a/_ur_addons/net/serve-http.mts
+++ b/_ur_addons/net/serve-http.mts
@@ -146,6 +146,7 @@ function Listen() {
   // apply static files middleware
   APP.use(express.static(http_docs));
 
+  //
   /** START HTTP SERVER **/
   SERVER = APP.listen(http_port, http_host, () => {
     LOG.info(`HTTP AppServer started on http://${http_host}:${http_port}`);

--- a/_ur_addons/net/serve-uds.mts
+++ b/_ur_addons/net/serve-uds.mts
@@ -60,7 +60,7 @@ function UDS_Listen() {
     // socket housekeeping
     const send = pkt => client_link.write(pkt.serialize());
     const onData = data => {
-      const returnPkt = EP._clientDataIngest(data, socket);
+      const returnPkt = EP._ingestClientMessage(data, socket);
       if (returnPkt) client_link.write(returnPkt.serialize());
     };
     const socket = new NetSocket(client_link, { send, onData });

--- a/_ur_addons/net/serve-wss.mts
+++ b/_ur_addons/net/serve-wss.mts
@@ -61,7 +61,7 @@ function WSS_Listen() {
     WSS.on('connection', (client_link, request) => {
       const send = pkt => client_link.send(pkt.serialize());
       const onData = data => {
-        const returnPkt = EP._clientDataIngest(data, client_sock);
+        const returnPkt = EP._ingestClientMessage(data, client_sock);
         if (returnPkt) client_link.send(returnPkt.serialize());
       };
       const client_sock = new NetSocket(client_link, { send, onData });

--- a/_ur_addons/net/urnet-constants-webclient.ts
+++ b/_ur_addons/net/urnet-constants-webclient.ts
@@ -16,7 +16,7 @@ type T_HTTP_CLIENT = {
   wss_url: string; // wss connection string
 };
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-const http_host = '127.0.0.1'; // http server host
+const http_host = '127.0.0.1'; // http server host forced to ipv4
 const http_port = 8080; // http server port
 const wss_path = 'urnet-http'; // websocket server path rel to host url:port
 const HTTP_CLIENT_INFO: T_HTTP_CLIENT = {

--- a/_ur_addons/net/urnet-constants-webclient.ts
+++ b/_ur_addons/net/urnet-constants-webclient.ts
@@ -1,0 +1,34 @@
+/*///////////////////////////////// ABOUT \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*\
+
+  URNET RUNTIME CONSTANTS for HTTP BROWSER CLIENTS
+
+\*\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\ * /////////////////////////////////////*/
+
+/// TYPES & INTERFACES ////////////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+/// HTTP servers are combined app and websocket servers on the same port!
+/// They build their webapp from a source directory before serving it.
+type T_HTTP_CLIENT = {
+  http_host: string; // http server host
+  http_port: number; // http server port
+  http_url: string; // full app url address
+  wss_path: string; // websocket server path rel to host url:port
+  wss_url: string; // wss connection string
+};
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+const http_host = '127.0.0.1'; // http server host
+const http_port = 8080; // http server port
+const wss_path = 'urnet-http'; // websocket server path rel to host url:port
+const HTTP_CLIENT_INFO: T_HTTP_CLIENT = {
+  http_host,
+  http_port,
+  http_url: `http://${http_host}:${http_port}`, //
+  wss_path: wss_path,
+  wss_url: `ws://${http_host}:${http_port}/${wss_path}`
+};
+
+/// EXPORTS ///////////////////////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+export {
+  HTTP_CLIENT_INFO // used for http and https server
+};

--- a/_ur_addons/net/urnet-constants.mts
+++ b/_ur_addons/net/urnet-constants.mts
@@ -5,41 +5,47 @@
 \*\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\ * /////////////////////////////////////*/
 
 import { FILE } from '@ursys/core';
+import CLIENT_CONSTANTS from './urnet-constants-webclient.ts';
+const { HTTP_CLIENT_INFO } = CLIENT_CONSTANTS;
 
 /// TYPES & INTERFACES ////////////////////////////////////////////////////////
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+/// these are the types of servers that can be enabled
 type TServerType = 'uds' | 'wss' | 'http';
-type T_UDS = { sock_file: string; sock_path: string };
-type T_WSS = {
-  wss_host: string;
-  wss_port: number;
-  wss_path: string;
-  wss_url: string;
+/// UDS servers just need a socket file path
+type T_UDS = {
+  sock_file: string; // socket file name
+  sock_path: string; // full socket file path
 };
+/// WSS servers are dedicated websocket servers running on a port and host
+type T_WSS = {
+  wss_host: string; // websocket server host
+  wss_port: number; // websocket server port
+  wss_path: string; // websocket server path rel to host url:port
+  wss_url: string; // wss connection string
+};
+/// HTTP servers are combined app and websocket servers on the same port!
+/// They build their webapp from a source directory before serving it.
 type T_HTTP = {
-  app_src: string;
-  app_index: string;
-  app_bundle: string;
-  app_bundle_map: string;
-  app_entry: string;
-  http_host: string;
-  http_port: number;
-  http_url: string;
-  http_docs: string;
-  wss_host: string;
-  wss_path: string;
-  wss_port: number;
-  wss_url: string;
-  https_port: number;
-  https_url: string;
+  http_host: string; // http server host
+  http_port: number; // http server port
+  app_src: string; // source directory for the app
+  app_index: string; // html file for the app
+  app_bundle: string; // js bundle file for app
+  app_bundle_map: string; // js bundle map file for app
+  app_entry: string; // js entry file for app bundling
+  http_url: string; // full app url address
+  http_docs: string; // express served files directory
+  wss_path: string; // websocket server path rel to host url:port
+  wss_url: string; // wss connection string
 };
 type TESBUILD = { es_target: string };
 
 /// RUNTIME CONTROL ///////////////////////////////////////////////////////////
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 /** Utility to set what servers should be enabled in net addon */
-const SERVERS: Set<TServerType> = new Set(['http', 'wss', 'uds']);
-// const SERVERS: Set<TServerType> = new Set(['http']);
+// const SERVERS: Set<TServerType> = new Set(['http', 'wss', 'uds']);
+const SERVERS: Set<TServerType> = new Set(['http']);
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 function UseServer(serverType: TServerType) {
   return SERVERS.has(serverType);
@@ -49,55 +55,35 @@ function UseServer(serverType: TServerType) {
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 const dir_addon_net = FILE.AbsLocalPath('_ur_addons/net');
 const sock_file = 'UDSHOST_nocommit.sock';
-const sock_path = `${dir_addon_net}/${sock_file}`;
 const UDS_INFO: T_UDS = {
-  sock_file, // socket file name
-  sock_path // full socket file path
+  sock_file,
+  sock_path: `${dir_addon_net}/${sock_file}`
 };
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 const wss_host = '127.0.0.1';
-const wss_port = 2929; // websocket server port
-const wss_path = '/urnet'; // websocket server path
+const wss_port = 2929;
+const wss_path = 'urnet';
 const WSS_INFO: T_WSS = {
-  wss_host, // websocket server host
-  wss_port, // websocket server port
-  wss_path, // websocket server path
+  wss_host,
+  wss_port,
+  wss_path,
   wss_url: `ws://${wss_host}:${wss_port}${wss_path}` // full wss url address
 };
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-const http_port = 8080;
-const https_port = 8443;
-const http_host = '127.0.0.1';
-const http_docs = FILE.AbsLocalPath('_ur_addons/_public');
-const app_src = FILE.AbsLocalPath('_ur_addons/net/serve-http-app');
-const app_index = 'index-net-http.html';
-const app_entry = '@app-init.ts';
-const app_bundle = 'js/net-http.bundle.js';
-const app_bundle_map = 'script/net-http.bundle.js.map';
-const http_url = `http://${http_host}:${http_port}`;
-const https_url = `https://${http_host}:${https_port}`;
-const http_wss_path = wss_path + '-http';
-const http_wss_port = wss_port + 100;
-const http_wss_host = wss_host;
-const http_wss_url = `ws://${http_wss_host}:${http_wss_port}${http_wss_path}`;
+const { wss_path: wss_path_http, wss_url: wss_url_http } = HTTP_CLIENT_INFO;
+const { http_host, http_port } = HTTP_CLIENT_INFO;
 const HTTP_INFO: T_HTTP = {
-  app_src, // source directory for the app
-  app_index, // html file for the app
-  app_bundle, // js bundle file for app
-  app_bundle_map, // js bundle map file for app
-  app_entry, // js entry file for app bundling
-  http_host, // http server host
-  http_port, // http server port
-  http_url, // full app url address (http://)
-  http_docs, // express served files directory
-  //
-  wss_host, // websocket server host
-  wss_path: http_wss_path, // websocket server path
-  wss_port: http_wss_port, // websocket server port
-  wss_url: http_wss_url, // full wss url address
-  //
-  https_port, // https server port
-  https_url // full app url address (https://)
+  app_src: FILE.AbsLocalPath('_ur_addons/net/serve-http-app'),
+  app_index: 'index-net-http.html',
+  app_bundle: 'js/net-http.bundle.js',
+  app_bundle_map: 'script/net-http.bundle.js.map',
+  app_entry: '@app-init.ts',
+  http_host,
+  http_port,
+  http_url: `http://${http_host}:${http_port}`, //
+  http_docs: FILE.AbsLocalPath('_ur_addons/_public'),
+  wss_path: wss_path_http,
+  wss_url: wss_url_http
 };
 
 /// BUILD SYSTEM INFO /////////////////////////////////////////////////////////

--- a/_ur_addons/net/urnet-types.ts
+++ b/_ur_addons/net/urnet-types.ts
@@ -43,6 +43,7 @@ export const VALID_PKT_TYPES = [
   '_reg', // special packet
   '_decl' // special packet
 ] as const;
+export const SKIP_SELF_PKT_TYPES = ['call', 'send'];
 export const VALID_ADDR_PREFIX = ['???', 'UR_', 'WSS', 'UDS', 'MQT', 'SRV'] as const;
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 export const UADDR_DIGITS = 3; // number of digits in UADDR (padded with 0)
@@ -96,6 +97,11 @@ export interface I_NetMessage {
 /** runtime check of NP_Type */
 export function IsValidType(msg_type: string): boolean {
   return VALID_PKT_TYPES.includes(msg_type as NP_Type);
+}
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+/** some message types should not invoke back to the same pkt origin */
+export function SkipOriginType(msg_type: string): boolean {
+  return SKIP_SELF_PKT_TYPES.includes(msg_type as NP_Type);
 }
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 /** runtime check of protocol-related NP_Type */


### PR DESCRIPTION
As I look into supporting https on remote servers like Digital Ocean, I think the architecture looks like this:

- the `node` app can continue to just work as a localhost development environment for both websockets and appserving via `express`
- `nginx` can be configured to handle both **https** redirection of an http connection _and_ **secure websocket** connection upgrading
- Websockets can also use the **same port** as another http server, so long as it has access to its instance and doesn't try to create its own. The standard is written to use the http protocol to initiate the connection, and then negotiate a different protocol other than http for efficiency if I am understanding this correctly.
- Lastly, multiple instances of our webapps can be handled by using `nginx` wildcard `location` definitions, though this creates some complexity in renewing our Lets Encrypt certificates. See wiki entry [[

## Proof of Concept Steps
- [X] Get this single port thing to work 
- [X] confirm it runs on Digital Ocean as regular http
- [X] add the websocket https upgrade code to express?
- [X] add the addition nginx location and relevant websocket upgrade to https headers
- [X] see if it works

## Tests Passed
- [X] on local mac, `ur net start` (set to just run http) and just browse to localhost:8080 and see if the console shows messages working
- [X] on digital ocean remote `ur net start` after nginx proxying is set up...works
- [X] check that works on localhost

## Bugs Fixed
- [X] Chrome client does not send "closing" websocket frame, which caused server not to remove clients from its message list by address. This required adding an `beforeunload` window event handler to call `EP.disconnectAsClient()` and also extend the `NetSocket` wrapper to accept a `close()` function.
- [X] This also was the cause of "messages not working when client reloads its page"
- [X] The `netCall` and `netSend` calls would reflect message invocation to _itself_, when this should only happen for `netPing` and `netSignal`.  

## Enhancements
- [X] a proof-of-concept utility to detect the locations in the `nginx` proxy `location` declarations to help the server show a list available locations.
