### PR TITLE
Detached Server Mode for URNet Messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ _public
 .package-lock.json
 
 # And don't commit personal log files or temp
+nohup.out
 *_log.md
 *.log
 tmp-*

--- a/_ur/common/util-prompts.js
+++ b/_ur/common/util-prompts.js
@@ -120,7 +120,7 @@ function m_MakeColorPromptFunction(prompt, colorName, opt = {}) {
         let RST = TERM_COLORS.Reset;
         let PR = padString(prompt);
         if (dim) TEXT += TERM_COLORS.Dim;
-        console.log(`${RST}${TAG}${PR}${RST}${TEXT}    ${str}`, ...args);
+        console.log(`${RST}${TAG}${PR}${RST}${TEXT}    ${str}`, ...args, RST);
       }
     : (str, ...args) => {
         if (args === undefined) args = '';

--- a/_ur_addons/@load-addon.mts
+++ b/_ur_addons/@load-addon.mts
@@ -24,6 +24,13 @@ const DBG = false;
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 const ARGS = process.argv.slice(2);
 
+/// SIGNAL HANDLING ///////////////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+/// this should allow 'nohup net start &' to work correctly
+process.on('SIGHUP', () => {
+  LOG(`ignoring SIGHUP received by @load-addon.mts`);
+});
+
 /// HELPER METHODS ////////////////////////////////////////////////////////////
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 async function ForkAddon(addonSelector: string) {

--- a/_ur_addons/net/@api-cli.mts
+++ b/_ur_addons/net/@api-cli.mts
@@ -2,6 +2,7 @@
 
   URSYS NET CLI
   invoked by the _ur/ur command line module loader
+  specific to the net addon
 
 \*\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\ * /////////////////////////////////////*/
 
@@ -26,6 +27,10 @@ const [m_script, m_addon, ...m_args] = PROC.DecodeAddonArgs(process.argv);
 const m_kvfile = PATH.join(process.cwd(), 'pid_keyv_nocommit.json');
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 let IS_MAIN = true; // set when no other @api-cli is running
+const m_allowed_flags = [
+  ['--detached', 'start'],
+  ['--kill', 'hosts'] // used by
+];
 
 /// HELPER FUNCTIONS //////////////////////////////////////////////////////////
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -42,6 +47,14 @@ function m_Sleep(ms, resolve?): Promise<void> {
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 /** keep track of main api script running status in the process list */
 async function InitializeCLI() {
+  // check flags
+  const m_flags = m_args.filter(arg => arg.startsWith('-'));
+  const m_allowed = m_allowed_flags.map(flopb => flopb[0]);
+  if (m_flags.some(f => !m_allowed.includes(f))) {
+    LOG.error(`invalid flags in ${m_flags.join(', ')}`);
+    LOG(`allowed flags are ${m_allowed_flags.join(', ')}`);
+    return;
+  }
   // initialize the key-value store
   await KV.InitKeyStore(m_kvfile);
   if (await KV.HasValue(m_script)) {
@@ -52,7 +65,7 @@ async function InitializeCLI() {
   IS_MAIN = true;
   if (DBG_CLI) LOG.info(`CLI: ${m_script} setting process signal handlers`);
 
-  // set up signaltermination
+  // set up signal intercepts
   process.on('SIGTERM', () => {
     console.log('\n');
     LOG(`SIGTERM received`);
@@ -79,6 +92,10 @@ async function InitializeCLI() {
       }
     })();
   });
+  // this might not be necessary; check nohup.out log for this message when
+  // invoking ur with nohup net cmd &
+  process.on('SIGHUP', () => LOG(`SIGHUP @api-cli ignored`));
+
   // save m_script without the -identifier suffix
   // the suffix is used by SpawnServer to create a unique identifier
   const pid = process.pid.toString();

--- a/_ur_addons/net/@api-cli.mts
+++ b/_ur_addons/net/@api-cli.mts
@@ -94,7 +94,7 @@ async function InitializeCLI() {
   });
   // this might not be necessary; check nohup.out log for this message when
   // invoking ur with nohup net cmd &
-  process.on('SIGHUP', () => LOG(`SIGHUP @api-cli ignored`));
+  process.on('SIGHUP', () => LOG(`ignoring SIGHUP received by @api-cli.mts`));
 
   // save m_script without the -identifier suffix
   // the suffix is used by SpawnServer to create a unique identifier

--- a/_ur_addons/net/cli-serve-control.mts
+++ b/_ur_addons/net/cli-serve-control.mts
@@ -18,8 +18,6 @@ const LOG = PR('Process', 'TagCyan');
 const DBG_PROC = true;
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 const [m_script, m_addon, ...m_args] = PROC.DecodeAddonArgs(process.argv);
-/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-let ALLOW_DETACH = false; // disables child process detaching for debugging
 
 /// UTILITY METHODS ///////////////////////////////////////////////////////////
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -76,7 +74,6 @@ async function SpawnServer(scriptName: string, id: string) {
 
   const pid = proc.pid.toString();
   await KV.SaveKey(pid, `${identifier}`);
-  if (ALLOW_DETACH) proc.unref();
 }
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 /** spawn all communication servers */
@@ -87,12 +84,10 @@ async function StartServers() {
     LOG.error(`!! server list is not empty...did you crash? use 'ur net stop'`);
     return;
   }
-  if (m_args.find(a => a === '--detached')) {
-    ALLOW_DETACH = true;
-    LOG.warn(`note: servers will be detached; use 'net hosts --kill' to terminate`);
-  } else {
-    LOG.warn(`note: 'net start' will not exit automatically; use ctrl-c to exit`);
-  }
+  LOG.warn(`note: To run in background, use 'nohup ur net start &'`);
+  LOG.warn(`      Use 'ur net stop' to terminate servers from any console`);
+  LOG.warn(`      Use 'tail -f nohup.out' to monitor server output/errors`);
+
   // main protocol host
   if (UseServer('uds')) await SpawnServer('./serve-uds.mts', 'uds');
   if (UseServer('wss')) await SpawnServer('./serve-wss.mts', 'wss');

--- a/_ur_addons/net/serve-http-app/client-http.ts
+++ b/_ur_addons/net/serve-http-app/client-http.ts
@@ -7,7 +7,7 @@
 import { ConsoleStyler } from '@ursys/core';
 import { NetEndpoint } from '../../net/class-urnet-endpoint.ts';
 import { NetSocket } from '../../net/class-urnet-socket.ts';
-import { HTTP_CLIENT_INFO } from '../../net/urnet-constants-webclient.ts';
+import { GetClientInfoFromWindowLocation } from '../../net/urnet-constants-webclient.ts';
 
 /// CONSTANTS & DECLARATIONS //////////////////////////////////////////////////
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -33,7 +33,7 @@ function m_Sleep(ms, resolve?): Promise<void> {
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 /** create a client connection to the HTTP/WS server */
 function Connect(): Promise<boolean> {
-  const { wss_url } = HTTP_CLIENT_INFO;
+  const { wss_url } = GetClientInfoFromWindowLocation(window.location);
   const promiseConnect = new Promise<boolean>(resolve => {
     LOG(...PR(`websocket connect to ${wss_url}`));
     SERVER_LINK = new WebSocket(wss_url);

--- a/_ur_addons/net/serve-http-app/index-net-http.html
+++ b/_ur_addons/net/serve-http-app/index-net-http.html
@@ -11,7 +11,7 @@
 <body>
   <div class="container">
     <!-- Your content here -->
-    <h1>Net Test Client for HTTP</h2>
+    <h1>URNet Message Test Client for HTTP and HTTPS</h2>
       <p>Open the <b>Javascript Console</b> to see URNET message tests.<br>(Chrome shortcuts: 🍎 CMD-OPT-J / 🪟
         CTRL-SHIFT-J)
       </p>

--- a/_ur_addons/net/serve-http-app/index-net-http.html
+++ b/_ur_addons/net/serve-http-app/index-net-http.html
@@ -11,7 +11,7 @@
 <body>
   <div class="container">
     <!-- Your content here -->
-    <h1>URNet Message Test Client for HTTP and HTTPS</h2>
+    <h1>URNet Message Test Client for HTTP/S</h2>
       <p>Open the <b>Javascript Console</b> to see URNET message tests.<br>(Chrome shortcuts: 🍎 CMD-OPT-J / 🪟
         CTRL-SHIFT-J)
       </p>

--- a/_ur_addons/net/serve-http.mts
+++ b/_ur_addons/net/serve-http.mts
@@ -46,6 +46,10 @@ process.on('SIGINT', () => {
     await Stop();
   })();
 });
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+/// this might not be necessary; check nohup.out log for this message when
+/// invoking ur with nohup net cmd &
+process.on('SIGHUP', () => LOG(`SIGHUP serve-http ignored`));
 
 /// DATA INIT /////////////////////////////////////////////////////////////////
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/_ur_addons/net/serve-http.mts
+++ b/_ur_addons/net/serve-http.mts
@@ -49,7 +49,7 @@ process.on('SIGINT', () => {
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 /// this might not be necessary; check nohup.out log for this message when
 /// invoking ur with nohup net cmd &
-process.on('SIGHUP', () => LOG(`SIGHUP serve-http ignored`));
+process.on('SIGHUP', () => LOG(`ignoring SIGHUP received by serve-http.mts`));
 
 /// DATA INIT /////////////////////////////////////////////////////////////////
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/_ur_addons/net/urnet-constants-webclient.ts
+++ b/_ur_addons/net/urnet-constants-webclient.ts
@@ -9,26 +9,53 @@
 /// HTTP servers are combined app and websocket servers on the same port!
 /// They build their webapp from a source directory before serving it.
 type T_HTTP_CLIENT = {
-  http_host: string; // http server host
-  http_port: number; // http server port
+  http_host: string; // http server host used by client app
+  http_port: number; // http server port used by client app
   http_url: string; // full app url address
   wss_path: string; // websocket server path rel to host url:port
   wss_url: string; // wss connection string
 };
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-const http_host = '127.0.0.1'; // http server host forced to ipv4
-const http_port = 8080; // http server port
+const http_host = '127.0.0.1'; // default set http server host forced to ipv4
+const http_port = 8080; // default http server port
 const wss_path = 'urnet-http'; // websocket server path rel to host url:port
-const HTTP_CLIENT_INFO: T_HTTP_CLIENT = {
+let HTTP_CLIENT_INFO: T_HTTP_CLIENT = {
   http_host,
   http_port,
   http_url: `http://${http_host}:${http_port}`, //
   wss_path: wss_path,
   wss_url: `ws://${http_host}:${http_port}/${wss_path}`
 };
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+/** Return new client info for a different hostname/path, which can not access
+ *  to default localhost but needs a real domain name-based server address.
+ *  Assumptions:
+ *  - nginx is proxying http to https on the server side
+ *  - no port is required, as this is handled by proxy
+ */
+function GetClientInfoFromWindowLocation(winLocation: Location) {
+  const { host, pathname, protocol } = winLocation;
+  console.log(`GetClientInfoFromWindowLocation: ${host} ${pathname} ${protocol}`);
+  const { http_port, wss_path } = HTTP_CLIENT_INFO;
+  const tls = protocol === 'https:';
+  const hostpath = host + pathname;
+  const http_url = tls ? `https://${hostpath}` : `http://${hostpath}:${http_port}`;
+  const wss_url = tls
+    ? `wss://${hostpath}/${wss_path}`
+    : `ws://${hostpath}:${http_port}/${wss_path}`;
+  let new_info = {
+    ...HTTP_CLIENT_INFO,
+    http_host: hostpath,
+    http_url,
+    wss_url
+  };
+  HTTP_CLIENT_INFO = new_info;
+  return new_info;
+}
 
 /// EXPORTS ///////////////////////////////////////////////////////////////////
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 export {
-  HTTP_CLIENT_INFO // used for http and https server
+  HTTP_CLIENT_INFO, // used for http and https server
+  GetClientInfoFromWindowLocation // return new client info for a different hostpath
 };

--- a/_ur_addons/net/urnet-constants-webclient.ts
+++ b/_ur_addons/net/urnet-constants-webclient.ts
@@ -39,10 +39,10 @@ function GetClientInfoFromWindowLocation(winLocation: Location) {
   const { http_port, wss_path } = HTTP_CLIENT_INFO;
   const tls = protocol === 'https:';
   const hostpath = host + pathname;
-  const http_url = tls ? `https://${hostpath}` : `http://${hostpath}:${http_port}`;
+  const http_url = tls ? `https://${hostpath}` : `http://${hostpath}`;
   const wss_url = tls
     ? `wss://${hostpath}/${wss_path}`
-    : `ws://${hostpath}:${http_port}/${wss_path}`;
+    : `ws://${hostpath}${wss_path}`;
   let new_info = {
     ...HTTP_CLIENT_INFO,
     http_host: hostpath,

--- a/_ur_addons/net/urnet-constants.mts
+++ b/_ur_addons/net/urnet-constants.mts
@@ -6,7 +6,7 @@
 
 import { FILE } from '@ursys/core';
 import CLIENT_CONSTANTS from './urnet-constants-webclient.ts';
-const { HTTP_CLIENT_INFO } = CLIENT_CONSTANTS;
+const { HTTP_CLIENT_INFO, GetClientInfoFromWindowLocation } = CLIENT_CONSTANTS;
 
 /// TYPES & INTERFACES ////////////////////////////////////////////////////////
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -


### PR DESCRIPTION
This PR add the ability to **run the server in the background** for the http server + client! It is tested to work for both localhost and Digital Ocean (DO) in both VSCODE's integrated terminal and a regular terminal.

## Testing Background Server

- pull the `dev-sri/websocket-protocol-detach` branch
- `npm ci && cd _ur`
- `nohup ur net start &`
- close the terminal window/visual studio code

This will run the server in the background, and you can visit it from a browser.

- if running on DO, browse to the location that the ursys repo is being routed to by nginx
- if running locally, browse to `localhost:8080`

Open two or three browser windows and open the javascript console to confirm operation. The test client app self-closes out after 360 seconds. To monitor the output of the server as clients connect/disconnect, use `tail -f nohup.out` 

## Technical Information

To make this work, I had to
- **Add `NOHUP` handlers** to key files, as the way the UR CLI works is by using a bash script to launch a node app that forks several children
- Change the client-side connection code to pass `window.location` to a function to return a **valid websocket connection string** based on the current protocol being `http` or `https`. While nginx handles the http proxying, the connection string has to match the protocol in use otherwise Chrome throws an error.

> [!WARNING]
> Fixes in this PR are limited to `serve-http`, and have **not been tested** with `serve-uds` or `serve-wss` modules