### PR TITLE
Check for existence of vsenv in VSCODE terminal profile script

### DIFF
--- a/.vscode/vs_env
+++ b/.vscode/vs_env
@@ -94,7 +94,7 @@ else
   printf "\n"
   printf "vsenv: ${ALRT}Missing .nvmrc file or .vscode folder${NRML}\n"
   printf "       This script is intended to be used within a VSCODE integrated terminal opened as a Code Workspace.\n"
-  printf "       The project folder should contain a .nvmrc file and a .vscode folder.\n"
+  printf "       The project folder should contain a .nvmrc file and a .vscode folder that has this script.\n"
 fi
 
 # for bash and zsh shells: if ./ is not in PATH, add it to end of PATH

--- a/ursys.code-workspace-example
+++ b/ursys.code-workspace-example
@@ -67,7 +67,7 @@
           "${env:SHELL}",
           "-i",
           "-c",
-          "export VSCODE_TERM='x86 shell';source ${workspaceFolder}/.vscode/vs_env; exec ${env:SHELL}"
+          "export VSCODE_TERM='x86 shell'; [ -f .vscode/vs_env ] && . .vscode/vs_env; exec ${env:SHELL}"
         ]
       },
       "arm64 macos": {
@@ -78,7 +78,7 @@
           "${env:SHELL}",
           "-i",
           "-c",
-          "export VSCODE_TERM='arm64 shell'; cd ${workspaceFolder}; source .vscode/vs_env; exec ${env:SHELL}"
+          "export VSCODE_TERM='arm64 shell'; cd ${workspaceFolder}; [ -f .vscode/vs_env ] && . .vscode/vs_env; exec ${env:SHELL}"
         ]
       },
       "generic macos": {
@@ -86,7 +86,7 @@
         "args": [
           "-i",
           "-c",
-          "export VSCODE_TERM='generic bash'; cd ${workspaceFolder}; source .vscode/vs_env; exec ${env:SHELL}"
+          "export VSCODE_TERM='generic bash'; cd ${workspaceFolder}; [ -f .vscode/vs_env ] && . .vscode/vs_env; exec ${env:SHELL}"
         ]
       }
     },
@@ -96,7 +96,7 @@
         "args": [
           "-i",
           "-c",
-          "export VSCODE_TERM='generic bash'; cd ${workspaceFolder}; source .vscode/vs_env; exec ${env:SHELL}"
+          "export VSCODE_TERM='generic bash'; cd ${workspaceFolder}; [ -f .vscode/vs_env ] && . .vscode/vs_env; exec ${env:SHELL}"
         ]
       }
     },


### PR DESCRIPTION
This PR handles how the `vs_env` environment checker script runs when an integrated terminal is opened in Visual Studio Code. 

## CHANGES

The CLI script for all profiles now include the `[-f]` file existence check so errors are no longer thrown. **It is up to the project folder** to include the `vs_env` script manually if this functionality is desired. It's built-into the top-level **ursys** project, but not necessarily `app-*` folders.

## BACKGROUND

The `vs_env` script lives in the `.vscode` directory and does some sanity checks:
- whether `nvm` is installed 
- whether the found version of **node** binary matches `.nvmrc` 
- detects the machine architecture

![image](https://github.com/user-attachments/assets/133804c1-ee8e-41af-a437-cf22b1bd2bcb)

The way that the script is invoked happens through a loaded **.code-workspace** project file, which defines several [Teminal Profiles](https://code.visualstudio.com/docs/terminal/profiles) that are selectable. This was used to **force X86** emulation on ARM-based Macs for particular projects. Here's what the `.code-workspace` for a working project looks like.

![image](https://github.com/user-attachments/assets/8206b710-1e42-45a7-a7eb-9c785fe1b574)

For example, to force the project to use macos x86 emulation, I'd change:
```
    "terminal.integrated.defaultProfile.osx": "generic macos",
```
to
```
    "terminal.integrated.defaultProfile.osx": "x86 macos",
```

> [!NOTE]
> The script does not run **unless** (1) loading a `.code-workspace` into Visual Studio Code and (2) an integrated terminal is opened within Visual Studio Code.
