### PR TITLE
Add `new:addon` command to UR command line script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,22 +14,20 @@
 /jot-*
 /sna-*
 
-# URSYS apps use a common runtime directory
-/runtime
-
-# ignore dynamically-generated bundle entry point
-**/__app_imports.ts
-
-# _dist is the esbuild out directory for _ur and _ur_addons
-# _runtime is used by apps in the root level of the framework
-_dist
-_public
-**/_dist
-**/_runtime*
-
+# URSYS user addons shouldn't been committed to the framework
+/_ur_addons/x-*
 
 # don't commit _nocommit files or directories
 *_nocommit*
+
+# ignore generated directories and files
+# _runtime is used by apps in the root level of the framework
+_public
+_dist
+**/_dist
+/runtime
+**/_runtime*
+**/__app_imports.ts
 
 # Also ignore build system directories
 .npmignore

--- a/_ur/npm-scripts/@install-addon.mts
+++ b/_ur/npm-scripts/@install-addon.mts
@@ -1,0 +1,141 @@
+/*///////////////////////////////// ABOUT \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*\
+
+  URSYS Bare Module Template
+  - for detailed example, use snippet 'ur-module-example' instead
+
+\*\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\ * /////////////////////////////////////*/
+
+import { execSync } from 'child_process';
+import * as https from 'https';
+import * as fs from 'node:fs';
+import * as PATH from 'node:path';
+import * as zlib from 'zlib';
+
+/// TYPE DECLARATIONS /////////////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+type URIHandler = (uri: string, targetDir: string) => Promise<void>;
+
+/// CONSTANTS & DECLARATIONS //////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+const TEMP_DIR = PATH.join(__dirname, 'temp');
+const TARGET_DIR = PATH.join(__dirname, 'target-directory');
+
+/// HELPER METHODS ////////////////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+// Helper Functions
+function isGitHubRepo(uri: string): boolean {
+  return uri.endsWith('.git');
+}
+
+function isArchiveFile(uri: string): boolean {
+  return uri.endsWith('.tar.gz') || uri.endsWith('.zip');
+}
+
+/// SUPPORT METHODS ///////////////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+function runCommand(command: string, options: { cwd?: string } = {}): void {
+  try {
+    console.log(`Running: ${command}`);
+    execSync(command, { stdio: 'inherit', ...options });
+  } catch (error) {
+    console.error(`Command failed: ${command}`);
+    throw error;
+  }
+}
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+function downloadFile(url: string, dest: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const file = fs.createWriteStream(dest);
+    https
+      .get(url, response => {
+        if (response.statusCode !== 200) {
+          reject(new Error(`Failed to download file: ${response.statusCode}`));
+          return;
+        }
+        response.pipe(file);
+        file.on('finish', () => file.close(() => resolve()));
+      })
+      .on('error', err => {
+        fs.unlinkSync(dest);
+        reject(err);
+      });
+  });
+}
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+async function extractTarGz(filePath: string, extractDir: string): Promise<void> {
+  const tar = await import('tar'); // Dynamically import for TypeScript support
+  await tar.extract({ file: filePath, cwd: extractDir });
+}
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+async function extractZip(filePath: string, extractDir: string): Promise<void> {
+  const unzipProcess = execSync(`unzip ${filePath} -d ${extractDir}`);
+  if (unzipProcess) {
+    console.log(`Unzipped file to ${extractDir}`);
+  }
+}
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+function copyDirectory(source: string, destination: string): void {
+  if (!fs.existsSync(source)) {
+    throw new Error(`Source directory does not exist: ${source}`);
+  }
+
+  fs.mkdirSync(destination, { recursive: true });
+
+  const items = fs.readdirSync(source, { withFileTypes: true });
+  items.forEach(item => {
+    const srcPath = PATH.join(source, item.name);
+    const destPath = PATH.join(destination, item.name);
+
+    if (item.isDirectory()) {
+      copyDirectory(srcPath, destPath);
+    } else {
+      fs.copyFileSync(srcPath, destPath);
+    }
+  });
+}
+
+/// MAIN API //////////////////////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+const handleURI: URIHandler = async (uri, targetDir) => {
+  try {
+    if (isGitHubRepo(uri)) {
+      console.log(`Detected GitHub repository: ${uri}`);
+      runCommand(`git clone ${uri} ${TEMP_DIR}`);
+      copyDirectory(TEMP_DIR, targetDir);
+      fs.rmSync(TEMP_DIR, { recursive: true, force: true });
+    } else if (isArchiveFile(uri)) {
+      console.log(`Detected archive file: ${uri}`);
+      const archivePath = PATH.join(TEMP_DIR, 'downloaded-archive');
+      await downloadFile(uri, archivePath);
+      fs.mkdirSync(TEMP_DIR, { recursive: true });
+
+      if (uri.endsWith('.tar.gz')) {
+        await extractTarGz(archivePath, TEMP_DIR);
+      } else if (uri.endsWith('.zip')) {
+        await extractZip(archivePath, TEMP_DIR);
+      }
+
+      copyDirectory(TEMP_DIR, targetDir);
+      fs.rmSync(TEMP_DIR, { recursive: true, force: true });
+      fs.unlinkSync(archivePath);
+    } else {
+      throw new Error(
+        'Unsupported URI format. Must be a GitHub repository or an archive file.'
+      );
+    }
+    console.log('Done!');
+  } catch (error) {
+    console.error('Error:', error.message);
+  }
+};
+
+/// RUNTIME ///////////////////////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+// Example Execution
+(async () => {
+  const URI = 'https://github.com/owner/repo.git'; // Replace with the desired URI
+  await handleURI(URI, TARGET_DIR);
+})();
+
+/// EXPORTS ///////////////////////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/_ur/ur
+++ b/_ur/ur
@@ -26,7 +26,7 @@ BRITE=$(tput bold)
 
 
 usage() {
-    COMMANDS="build test"
+    COMMANDS="build test new:addon"
     ADDONS=""
     a_dirs=$(find "$ADDONS_LIB" -mindepth 1 -maxdepth 1 -type d -name "[!_]*" -exec basename {} \;)
     a_dirs=$(prln "$a_dirs" | tr '\n' ' ')
@@ -103,6 +103,34 @@ case "$1" in
             prln "${YELLOW}unknown test option: '$2'${RESET}"
             exit 1;
         fi
+        exit 0;
+        ;;
+
+    new:addon)
+        # get additional argument after 'new' into $option
+        prln ""
+        if [ -z "$2" ]; then
+            prln "${BGBLUE} new:addon ${RESET} ${BRITE}Provide short addon name.${RESET} Use ${YELLOW}x-${RESET} prefix for user addons that will be"
+            prln "excluded from the main URSYS repo (e.g. x-myaddon)"
+            prln ""
+            exit 1;
+        fi
+        # make sure the addon doesn't already exist
+        if [ -d "$ADDONS_LIB/$2" ]; then
+            prln "${BGBLUE} new:addon ${RESET} $2 already exists"
+            prln ""
+            exit 1;
+        fi
+        # clone the addon template and remove the .git directory
+        git clone --depth 1 https://github.com/dsriseah/ursys-x-sna-addon.git $ADDONS_LIB/$2
+        rm -fr $ADDONS_LIB/$2/.git
+        if [ "${2:0:2}" = "x-" ]; then
+            prln "${BGBLUE} new:addon ${RESET} created new user addon: $2"
+        else
+            prln "${BGBLUE} new:addon ${RESET} created new addon: $2"
+        fi
+        cd $ADDONS_LIB/$2
+        prln ""
         exit 0;
         ;;
 esac

--- a/_ur_addons/package.json
+++ b/_ur_addons/package.json
@@ -28,8 +28,10 @@
     "node-dir": "^0.1.17",
     "vitest": "^1.6.0"
   },
+  "peerDependencies": {
+    "@ursys/core": "file:../_ur"
+  },
   "dependencies": {
-    "@ursys/core": "file:../_ur",
     "chokidar": "^3.5.3",
     "express": "^4.19.2",
     "graphology": "^0.25.4",


### PR DESCRIPTION
You can now type `ur new:addon <addon_name>` to clone the contents of `github.com/dsriseah/ursys-x-sna-addon` into the `_ur_addons` directory to simplify creation of addons.

## TESTING

**See new command listing**
```
cd _ur
ur
```
displays the `new:addon` command in the list

**Create an addon**
```
ur new:addon addon_name
```
This creates a new addon called `addon_name` and prints a message "created new addon". 
- `ur` to see the new addon in the list. 
- `ur addon_name` to run it and browse to `localhost:8080` to see the test webserver.
- confirm that the `addon_name` directory is now under source control of the parent URSYS repo

**Create a user addon**
User addons begin with `x`, and the parent URSYS repo is configured to ignore them.
```
ur new:addon x-addon
```
This creates the `x-addon` directory, with the message `created new user addon`.
- `ur` to see the new addon in the list
- ` ur x-addon` to make sure it runs
- confirm that `x-addon` is **not** under source control of the main URSYS repo. 

**Put a user addon under independent source control**
- `cd _ur_addons/x-addon`
- `git init`
You can now independently manage this git and push it up to the main repo. To share this addon with other users, you can provide the following instructions:
```
cd _ur_addons
git clone --depth 1 https://path-to-repo x-addon-name-to-use
rm -fr ./x-addon-name-to-use/.git
```

## BONUS UTILITY

This repo can also be used to create **standlone apps** in the main root of the URSYS repo, which are ignored in a similar way if the prefixes `sna-`, `app-` and `example-` are used. You will need to add your own `package.json` and npm scripts to execute the node entry point `@server.mts`. The resulting app's `_public` folder can be uploaded as a stand-alone website, unless you are using server-side features of the development server.
